### PR TITLE
Automatically render raw links as anchors

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -5,7 +5,14 @@ document.addEventListener("DOMContentLoaded", function(event) {
     return;
   }
 
-  const md = window.markdownit().use(window.markdownitFootnote).use(window.markdownitTaskLists);
+  var mardownitOptions = {
+      // automatically render raw links as anchors.
+      linkify: true
+  };
+
+  const md = window.markdownit(markdownitOptions)
+    .use(window.markdownitFootnote)
+    .use(window.markdownitTaskLists);
 
   var editor = document.getElementById("editor");
   var preview = document.getElementById("preview");
@@ -31,7 +38,7 @@ document.addEventListener("DOMContentLoaded", function(event) {
     if(note.isMetadataUpdate) {
       return;
     }
-    
+
     editor.value = note.content.text;
     preview.innerHTML = md.render(note.content.text);
   });


### PR DESCRIPTION
Hi! I just enabled an option that I find useful in the markdownit renderer: the capacity to automatically render raw links as anchors.

For instance, say you have in your md source something like `go to https://standardnotes.org and click blahblah`. With this option enabled, the rendered text will contain an anchor to the website, although there's no markdown code for the link.

What do you think about enabling this in general? It's pretty cheap, and it's proven quite useful to me.