### PR TITLE
Add support for synced scroll

### DIFF
--- a/app/components/Home.js
+++ b/app/components/Home.js
@@ -31,6 +31,7 @@ export default class Home extends React.Component {
     this.connectToBridge();
     this.updatePreviewText();
     this.addChangeListener();
+    this.addScrollListeners();
 
     this.configureResizer();
     this.addTabHandler();
@@ -98,7 +99,7 @@ export default class Home extends React.Component {
       this.setState({platform: this.componentManager.platform});
     });
 
-    // componentManager.loggingEnabled = true;
+    // this.componentManager.loggingEnabled = true;
 
     this.componentManager.streamContextItem((note) => {
       this.note = note;
@@ -145,6 +146,29 @@ export default class Home extends React.Component {
           note.content.preview_html = null;
         });
       }
+    })
+  }
+
+  addScrollListeners() {
+    this.scrollTriggers = {};
+    this.syncScroll(this.editor, this.preview);
+    this.syncScroll(this.preview, this.editor);
+  }
+
+  syncScroll(source, destination) {
+    source.addEventListener('scroll', (event) => {
+      // Avoid the cascading effect by not handling the event if it was triggered initially by this element
+      if (this.scrollTriggers[source] === true) {
+        this.scrollTriggers[source] = false;
+        return;
+      }
+      this.scrollTriggers[source] = true;
+
+      var target = event.target
+      var height = target.scrollHeight - target.clientHeight;
+      var ratio = parseFloat(target.scrollTop) / height;
+      var move = (destination.scrollHeight - destination.clientHeight) * ratio;
+      destination.scrollTop = move;
     })
   }
 


### PR DESCRIPTION
This PR adds support for synced scroll between the editor and preview pane. 

It uses the ratio between the height of both viewports as a heuristic to keep them in sync.

Here's an example of it in action:

![sme](https://user-images.githubusercontent.com/10207818/58343117-3138da80-7e4a-11e9-8882-9ee5d91bb507.gif)

Closes standardnotes/bounties#22