### PR TITLE
feat: split panels evenly

### DIFF
--- a/app/stylesheets/main.scss
+++ b/app/stylesheets/main.scss
@@ -27,6 +27,10 @@ body, html {
 
   background-color: var(--sn-stylekit-editor-background-color);
   color: var(--sn-stylekit-editor-foreground-color);
+
+  .sk-label {
+    width: 48px;
+  }
 }
 
 #editor-container {
@@ -47,7 +51,7 @@ body, html {
   }
 
   &.split {
-    width: calc(50% - 20px);
+    width: calc(50% - 4px);
   }
 
   &.preview {
@@ -78,9 +82,8 @@ body, html {
 }
 
 #preview {
-  padding: 10px;
+  padding: 12px;
   padding-top: 0;
-  padding-left: 16px;
   -webkit-overflow-scrolling: touch;
 
   background-color: var(--sn-stylekit-background-color);
@@ -93,7 +96,7 @@ body, html {
   }
 
   &.split {
-    width: calc(50% - 20px);
+    width: calc(50% - 4px);
   }
 
   &.preview {


### PR DESCRIPTION
Split both panels evenly.

I also made the edit/split/preview buttons the same size so they would sit perfectly between both panels.

Old buttons:

![image](https://user-images.githubusercontent.com/10207818/58410483-31172580-806a-11e9-8749-7a41c9735593.png)

New buttons:

![image](https://user-images.githubusercontent.com/10207818/58410515-40966e80-806a-11e9-93d5-dc685ad67641.png)

Closes standardnotes/bounties#25